### PR TITLE
replaced test on accessory page

### DIFF
--- a/cypress/integration/accessoriesTest.js
+++ b/cypress/integration/accessoriesTest.js
@@ -1,15 +1,13 @@
 import HomePage from '../../src/pages/HomePage'
 import AccessoriesPage from '../../src/pages/AccessoriesPage'
-import ScreenPage from '../../src/pages/ScreenProtectorPage'
-import * as screenData from '../../testData/screenProtectorData'
 import * as urls from '../../testData/urls'
+import * as accessories from '../../testData/accessoriesData'
 
 describe("Navigation on Accessories page", ()=>{
     
-    it("Verify redirect to screen protector page", ()=>{      
+    it("Verify redirect to protection page", ()=>{      
         HomePage.openUrl(urls.accessoriesUrl)  
-        AccessoriesPage.selectAccessory(AccessoriesPage.cover)
-        AccessoriesPage.selectType(AccessoriesPage.screenType)
-        cy.get(ScreenPage.firstItem).should('contain', screenData.sceenTitle)
+        AccessoriesPage.selectAccessory(AccessoriesPage.protection)
+        cy.get(AccessoriesPage.protectorsTitle).should('contain', accessories.protectorPageTitle)
     })
 })

--- a/cypress/integration/screenProtectorTest.js
+++ b/cypress/integration/screenProtectorTest.js
@@ -14,6 +14,13 @@ describe("Verification of filters for screen protector", ()=>{
         ScreenPage.selectType(AccessoriesPage.screenProtectionGlass)
     })
 
+    it("Verify redirect to screen protector page", ()=>{      
+        HomePage.openUrl(urls.accessoriesUrl)  
+        AccessoriesPage.selectAccessory(AccessoriesPage.protection)
+        AccessoriesPage.selectType(AccessoriesPage.screenType)
+        cy.get(ScreenPage.firstItem).should('contain', screenData.sceenTitle)
+    })
+
     it("Verification of sorting by color if 'Черный' is selected", ()=>{  
         ScreenPage.selectColor(ScreenPage.blackColor)
         cy.get(ScreenPage.firstItem).should('contain', screenData.blackFrame)

--- a/src/pages/AccessoriesPage.js
+++ b/src/pages/AccessoriesPage.js
@@ -1,9 +1,9 @@
 class AccessoriesPage {
-    cover = '#bx_1847241719_ > * > *> *> * > [href="/accessories/protection"]'
+    protection = '#bx_1847241719_ > * > *> *> * > [href="/accessories/protection"]'
     screenProtectionGlass = "//*[contains(text(),'Защитное')]"
     accessoryType = "//div[contains(text(),'Тип аксессуара')]"
     screenType = "//span[contains(text(),'Защитное стекло')]"
-
+    protectorsTitle = "//span[contains(text(),'Защитные аксессуары')]"
 
     selectAccessory(accessory) {
         cy.get(accessory).click({ force: true })

--- a/testData/accessoriesData.js
+++ b/testData/accessoriesData.js
@@ -1,0 +1,1 @@
+export const protectorPageTitle = "Защитные аксессуары"


### PR DESCRIPTION
Replaced "Verify redirect to protection page" test with "Verify redirect to screen protector page" on "Accessories" tests. Added locators for the new tests.